### PR TITLE
PP-4516 Improve http error handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.idea

--- a/functions.js
+++ b/functions.js
@@ -58,6 +58,8 @@ module.exports.retrieveDailyPerformanceStatsForDate = async function(connectorUr
     request.get(reportUrl, (err, response, body) => {
       if (err) {
         reject(err)
+      } else if (response && response.statusCode !== 200) {
+        reject(`Got an unsuccessful response. Status code: ${response.statusCode}`)
       } else {
         resolve(JSON.parse(body))
       }
@@ -92,6 +94,8 @@ module.exports.sendStatsToPerformancePlatform = function (date, report, apiKey) 
     }, (err, response, body) => {
       if (err) {
         reject(err)
+      } else if (response && response.statusCode !== 200) {
+        reject(`Got an unsuccessful response. Status code: ${response.statusCode}, message: ${response.body.messages}`)
       } else {
         resolve([response, body])
       }


### PR DESCRIPTION
Previously when call ing a downstream service we counted anything that wasn't an error as a  successful call to a service (either to connector or to perf platform).
The `request` library only sets the `error` object if the http call has failed - e.g the connection timed out or  connection was refused - it doesn't include receiving HTTP error response. This commit checks that the call receives a 200 (a bit simplistic, but correct for this case) and if not rejects the promise, ensuring we log something useful and don't believe all is fine when it patently is not.