### PR TITLE
PP-4491: Remove chamber scripts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-FROM govukpay/nodejs:8.11.3
+FROM govukpay/nodejs:alpine-3.8.1
 WORKDIR /app
 ADD . /app
 RUN npm install
-CMD 'tail -f /dev/null'
+CMD ["node" "index.js"]

--- a/README.md
+++ b/README.md
@@ -7,12 +7,12 @@ We also have the ability to run it to backfill data for specific days.
 
 ## Required environment variables
 
-- PERFORMANCE_PLATFORM_API_KEY - GOV.UK Performance platform [API key](https://performance-platform.readthedocs.io/)
-- CONNECTOR_URL - URL of connector you want to retrieve data from
+- `PERFORMANCE_PLATFORM_API_KEY` - GOV.UK Performance platform [API key](https://performance-platform.readthedocs.io/)
+- `CONNECTOR_URL` - URL of connector you want to retrieve data from
 
 ## Optional environment variable
 
-- DAYS_TO_BACKFILL 
+- `DAYS_TO_BACKFILL` 
   > If there is missing data that needs backfilling you can provide
   the number of days you need to backfill, so if it was just yesterday
   do `DAYS_TO_BACKFILL=1` and if it was last week do `DAYS_TO_BACKFILL=7`

--- a/run-with-chamber.sh
+++ b/run-with-chamber.sh
@@ -1,3 +1,0 @@
-#!/usr/bin/env ash
-
-AWS_REGION="${ECS_AWS_REGION}" chamber exec "${ECS_SERVICE}" -- node index.js


### PR DESCRIPTION
We no longer use chamber now that ECS supports pulling secrets directly from
parameter store.

Remove the script and change the entrypoint for the container to run the
application directly.

Also, update to our latest alpine 3.8.1 base image, which doesn't include
chamber.