### PR TITLE
RED-46: Stop using our node base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,10 @@
-# govukpay/nodejs:alpine-3.8.1
-FROM govukpay/nodejs@sha256:a3ae1b0b3ab5e7cdefe0787b97b1047cdc5e0c5166fb677e3cefac538bc99f86
+# alpine:3.8
+FROM alpine@sha256:ea47a59a33f41270c02c8c7764e581787cf5b734ab10d27e876e62369a864459
+
+RUN ["apk", "--no-cache", "upgrade"]
+RUN ["apk", "add", "--no-cache", "nodejs", "npm"]
+
 WORKDIR /app
 ADD . /app
-RUN npm install
+RUN ["npm", "install"]
 CMD ["node" "index.js"]


### PR DESCRIPTION
Our base image doesn't do much. Import what it does into the local Dockerfile