### PR TITLE
PP-8263 Update the `pre-commit` and `detect-secrets` setup

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+repos:
+- repo: https://github.com/Yelp/detect-secrets
+  rev: f6027a0521e044ba46e54611cabd787b7a88d1a9 
+  hooks:
+    - id: detect-secrets
+      args: ['--baseline', '.secrets.baseline']
+      exclude: package.lock.json

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,19 +1,15 @@
 {
-  "exclude": {
-    "files": null,
-    "lines": null
-  },
-  "generated_at": "2020-10-29T11:28:37Z",
+  "version": "1.1.0",
   "plugins_used": [
-    {
-      "name": "AWSKeyDetector"
-    },
     {
       "name": "ArtifactoryDetector"
     },
     {
-      "base64_limit": 4.5,
-      "name": "Base64HighEntropyString"
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "Base64HighEntropyString",
+      "limit": 4.5
     },
     {
       "name": "BasicAuthDetector"
@@ -22,8 +18,8 @@
       "name": "CloudantDetector"
     },
     {
-      "hex_limit": 3,
-      "name": "HexHighEntropyString"
+      "name": "HexHighEntropyString",
+      "limit": 3
     },
     {
       "name": "IbmCloudIamDetector"
@@ -35,8 +31,8 @@
       "name": "JwtTokenDetector"
     },
     {
-      "keyword_exclude": null,
-      "name": "KeywordDetector"
+      "name": "KeywordDetector",
+      "keyword_exclude": ""
     },
     {
       "name": "MailchimpDetector"
@@ -57,277 +53,56 @@
       "name": "TwilioKeyDetector"
     }
   ],
+  "filters_used": [
+    {
+      "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
+    },
+    {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": ".secrets.baseline"
+    },
+    {
+      "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
+      "min_level": 2
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_indirect_reference"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_likely_id_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_lock_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_not_alphanumeric_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_potential_uuid"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_prefixed_with_dollar_sign"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_sequential_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_swagger_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_templated_secret"
+    }
+  ],
   "results": {
-    "package-lock.json": [
+    ".pre-commit-config.yaml": [
       {
-        "hashed_secret": "c73aa44f0e55aa2bceeb8dff2bff186fc52a00d0",
+        "type": "Hex High Entropy String",
+        "filename": ".pre-commit-config.yaml",
+        "hashed_secret": "d8371c23f86b4df4be2854848f6f28f13d7582f5",
         "is_verified": false,
-        "line_number": 10,
-        "type": "Base64 High Entropy String"
-      },
-      {
-        "hashed_secret": "f1dbba169db046906924ccd784068a2306096634",
-        "is_verified": false,
-        "line_number": 21,
-        "type": "Base64 High Entropy String"
-      },
-      {
-        "hashed_secret": "2c7bd6cdc39b5b8a0f32aa11988a0ec769526cdb",
-        "is_verified": false,
-        "line_number": 29,
-        "type": "Base64 High Entropy String"
-      },
-      {
-        "hashed_secret": "9787d966f19a0d8d0021b31d34cfdfcebdb9c28a",
-        "is_verified": false,
-        "line_number": 34,
-        "type": "Base64 High Entropy String"
-      },
-      {
-        "hashed_secret": "fa83dcbf0f435ee38066d19a2a43815510f96bc4",
-        "is_verified": false,
-        "line_number": 39,
-        "type": "Base64 High Entropy String"
-      },
-      {
-        "hashed_secret": "efd950eb56154878a07eb620182df2222930cb1a",
-        "is_verified": false,
-        "line_number": 44,
-        "type": "Base64 High Entropy String"
-      },
-      {
-        "hashed_secret": "936b0959aa13f1decc76be1d80acaac0860847b7",
-        "is_verified": false,
-        "line_number": 49,
-        "type": "Base64 High Entropy String"
-      },
-      {
-        "hashed_secret": "80f8d53f3fedde239f695d6a4c44c78b4aff0a44",
-        "is_verified": false,
-        "line_number": 57,
-        "type": "Base64 High Entropy String"
-      },
-      {
-        "hashed_secret": "b4fe5b68c571e0f59b6531099e4a3d1810616380",
-        "is_verified": false,
-        "line_number": 62,
-        "type": "Base64 High Entropy String"
-      },
-      {
-        "hashed_secret": "7ea379a1bf787a21401c8c39f285e4e84b478d72",
-        "is_verified": false,
-        "line_number": 75,
-        "type": "Base64 High Entropy String"
-      },
-      {
-        "hashed_secret": "04450eaacfa844f84926d04d6a07534cde99b28e",
-        "is_verified": false,
-        "line_number": 83,
-        "type": "Base64 High Entropy String"
-      },
-      {
-        "hashed_secret": "acce4ef8d841ffa646256da3af7b79ad5cb78158",
-        "is_verified": false,
-        "line_number": 97,
-        "type": "Base64 High Entropy String"
-      },
-      {
-        "hashed_secret": "22e7ae9b65ade417baac61e6f0d84a54783ba759",
-        "is_verified": false,
-        "line_number": 102,
-        "type": "Base64 High Entropy String"
-      },
-      {
-        "hashed_secret": "0b4156cb54f1992ef4c771a529dd24d502ce300a",
-        "is_verified": false,
-        "line_number": 107,
-        "type": "Base64 High Entropy String"
-      },
-      {
-        "hashed_secret": "cf637caa1cabfbc87b73dd253c85c7fde22dd4ee",
-        "is_verified": false,
-        "line_number": 112,
-        "type": "Base64 High Entropy String"
-      },
-      {
-        "hashed_secret": "9cb2b0347722893cde39bbe83f9df7c3c6e1b7c3",
-        "is_verified": false,
-        "line_number": 117,
-        "type": "Base64 High Entropy String"
-      },
-      {
-        "hashed_secret": "344e37e02a35dd31cc7dc945b7fe7b2da88344c0",
-        "is_verified": false,
-        "line_number": 122,
-        "type": "Base64 High Entropy String"
-      },
-      {
-        "hashed_secret": "277e32c5ba00ef90c6f76c7004fde2ecac6d2e18",
-        "is_verified": false,
-        "line_number": 132,
-        "type": "Base64 High Entropy String"
-      },
-      {
-        "hashed_secret": "b95e69c7f4328ea641952f875c3b079a1585c9d1",
-        "is_verified": false,
-        "line_number": 140,
-        "type": "Base64 High Entropy String"
-      },
-      {
-        "hashed_secret": "6b30fe731c8444c0263b57aacbdaedb771ec01a5",
-        "is_verified": false,
-        "line_number": 145,
-        "type": "Base64 High Entropy String"
-      },
-      {
-        "hashed_secret": "bf47364c2d4ad0308ef016fe4a89f6c7dc21ef86",
-        "is_verified": false,
-        "line_number": 154,
-        "type": "Base64 High Entropy String"
-      },
-      {
-        "hashed_secret": "16225dde2ec301d038a0bdbda68de4a174fbfdd0",
-        "is_verified": false,
-        "line_number": 164,
-        "type": "Base64 High Entropy String"
-      },
-      {
-        "hashed_secret": "38952752ebde485c02a80bff1d81ebe95664bcca",
-        "is_verified": false,
-        "line_number": 169,
-        "type": "Base64 High Entropy String"
-      },
-      {
-        "hashed_secret": "535582d92da3a4158e592ec29868bfd8467b8bce",
-        "is_verified": false,
-        "line_number": 174,
-        "type": "Base64 High Entropy String"
-      },
-      {
-        "hashed_secret": "23b096d9b48ed5d9a778d3db5807c5c7a2357c93",
-        "is_verified": false,
-        "line_number": 179,
-        "type": "Base64 High Entropy String"
-      },
-      {
-        "hashed_secret": "127f92724797904fb4e6de2dfff2c71c07739612",
-        "is_verified": false,
-        "line_number": 184,
-        "type": "Base64 High Entropy String"
-      },
-      {
-        "hashed_secret": "bc788b9febb8e95114c2e78a9d5297f80bbedb2c",
-        "is_verified": false,
-        "line_number": 194,
-        "type": "Base64 High Entropy String"
-      },
-      {
-        "hashed_secret": "6c83ec98bea7a11b8cd05d82b6cfaca7293eb204",
-        "is_verified": false,
-        "line_number": 205,
-        "type": "Base64 High Entropy String"
-      },
-      {
-        "hashed_secret": "f12b146873660c38d6ed8bf9132b479254ac579a",
-        "is_verified": false,
-        "line_number": 210,
-        "type": "Base64 High Entropy String"
-      },
-      {
-        "hashed_secret": "75a3c0b9934bd460ff7af9763edb25d749ab7b4e",
-        "is_verified": false,
-        "line_number": 218,
-        "type": "Base64 High Entropy String"
-      },
-      {
-        "hashed_secret": "97cbb7fbdfe498c80489e26bcdc78fce5db9b258",
-        "is_verified": false,
-        "line_number": 223,
-        "type": "Base64 High Entropy String"
-      },
-      {
-        "hashed_secret": "7b916640c97ee0721124cd263456522d49c6fc41",
-        "is_verified": false,
-        "line_number": 228,
-        "type": "Base64 High Entropy String"
-      },
-      {
-        "hashed_secret": "7a87fb248397359e9c6ca6e46f39805789059102",
-        "is_verified": false,
-        "line_number": 233,
-        "type": "Base64 High Entropy String"
-      },
-      {
-        "hashed_secret": "401f90e6afa890c5ee44071351e4a149e7c1f5e0",
-        "is_verified": false,
-        "line_number": 238,
-        "type": "Base64 High Entropy String"
-      },
-      {
-        "hashed_secret": "07edb92aa7dfef74574388b9e108ea88e806a9f2",
-        "is_verified": false,
-        "line_number": 243,
-        "type": "Base64 High Entropy String"
-      },
-      {
-        "hashed_secret": "d5e822897b1f37e6ce1a864e2ba9af8f9bfc5539",
-        "is_verified": false,
-        "line_number": 270,
-        "type": "Base64 High Entropy String"
-      },
-      {
-        "hashed_secret": "1508bbaf29927b5348d4df62823dab122a0d3b48",
-        "is_verified": false,
-        "line_number": 275,
-        "type": "Base64 High Entropy String"
-      },
-      {
-        "hashed_secret": "0f47f4a6b9f65b0adce5a0eb126fb11fc7c78a2b",
-        "is_verified": false,
-        "line_number": 280,
-        "type": "Base64 High Entropy String"
-      },
-      {
-        "hashed_secret": "d81ef3dc010ac8624a49d224bd779823b6279e8e",
-        "is_verified": false,
-        "line_number": 296,
-        "type": "Base64 High Entropy String"
-      },
-      {
-        "hashed_secret": "18469023a89dd192b5275d8b955c9fd2202e0c03",
-        "is_verified": false,
-        "line_number": 312,
-        "type": "Base64 High Entropy String"
-      },
-      {
-        "hashed_secret": "0d3ce7468071b4e48ba9cd014ade7037dc57ef41",
-        "is_verified": false,
-        "line_number": 320,
-        "type": "Base64 High Entropy String"
-      },
-      {
-        "hashed_secret": "42e05c82cd06a9ed1d15e0f472c2efc4b3254cae",
-        "is_verified": false,
-        "line_number": 325,
-        "type": "Base64 High Entropy String"
-      },
-      {
-        "hashed_secret": "6f9bfb49cb818d2fe07592515e4c3f7a0bbd7e0e",
-        "is_verified": false,
-        "line_number": 333,
-        "type": "Base64 High Entropy String"
-      },
-      {
-        "hashed_secret": "9e897caf5658aea914e1034f46663cadb5a76348",
-        "is_verified": false,
-        "line_number": 338,
-        "type": "Base64 High Entropy String"
+        "line_number": 3
       }
     ]
   },
-  "version": "0.13.1",
-  "word_list": {
-    "file": null,
-    "hash": null
-  }
+  "generated_at": "2021-08-13T16:52:32Z"
 }


### PR DESCRIPTION
- Add a local `.pre-commit.yaml`
  - This will run `detect-secrets` when you try to commit a file.
- Update the existing `.secrets.baseline` file
  - To ignore the SHA specified in the `.pre-commit.yaml`